### PR TITLE
Minor improvements

### DIFF
--- a/louis-sys/Cargo.toml
+++ b/louis-sys/Cargo.toml
@@ -12,7 +12,7 @@ links = "louis"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.37.4"
+bindgen = "0.59.2"
 pkg-config = "0.3.14"
 autotools = "0.1.2"
 log = "0.4.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl Louis {
     /// # let louis = Louis::new().unwrap();
     /// let txt = "This is another way to make dots.";
     /// let dots = louis.translate_simple("unicode.dis,en_US.tbl", txt, false, 0);
-    /// assert_eq!(dots, "⠠⠹ ⠊⠎ ⠁⠝⠕⠮⠗ ⠺⠁⠽ ⠖⠍⠁⠅⠑ ⠙⠕⠞⠎⠲");
+    /// assert_eq!(dots, "⠠⠹⠀⠊⠎⠀⠁⠝⠕⠮⠗⠀⠺⠁⠽⠀⠖⠍⠁⠅⠑⠀⠙⠕⠞⠎⠲");
     /// ```
     ///
     pub fn translate_simple(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,7 +27,7 @@ fn translate_simple_de() {
     let sentence = "Dies ist ein kurzer Satz.";
     let louis = API.lock().unwrap();
     assert_eq!(
-        louis.translate_simple("de.tbl", sentence, false, 0),
+        louis.translate_simple("de-g2.ctb", sentence, false, 0),
         "d0s } 6 kz7 sz."
     );
 }


### PR DESCRIPTION
1. Fixed test dependent on `de.tbl`, which is now called `de-gr2.ctb`.
2. Fixed doctest which assumes unicode mode outputs a space, when it actually outputs an empty braille cell.
3. Bump `bindgen` version to work with other new crates which link to `clang-sys`.